### PR TITLE
更新挑战系统，允许少量相似字符

### DIFF
--- a/src/main/kotlin/Challenge.kt
+++ b/src/main/kotlin/Challenge.kt
@@ -76,16 +76,44 @@ suspend fun newChallenge(g: Group): ByteArray {
 @OptIn(DelicateCoroutinesApi::class)
 fun configureTypeTextChallenge(bot: Bot) {
     bot.eventChannel.subscribeAlways<GroupMessageEvent> {
-        if (message.content == lastKey) {
-            lastKey = null
-            val reward = (3..10).random() +
-                    if (lastWinner == sender.id) {
-                        group.sendMessage("连续答对，额外赠送5金币！")
-                        5
-                    } else 0
-            lastWinner = sender.id
-            group.sendMessage("恭喜${sender.nick}获得胜利, 获得 $reward 金币！")
-            sender.profile.increaseMoney(reward.toDouble())
+        if (lastKey != null) {
+            if (message.content == lastKey) {
+                lastKey = null
+                val reward = (3..10).random() +
+                        if (lastWinner == sender.id) {
+                            group.sendMessage("连续答对，额外赠送5金币！")
+                            5
+                        } else 0
+                lastWinner = sender.id
+                group.sendMessage("恭喜${sender.nick}获得胜利, 获得 $reward 金币！")
+                sender.profile.increaseMoney(reward.toDouble())
+            } else if (message.content.length == (lastKey?.length ?: -1)) {
+                val similarCharacters: MutableList<String> = mutableListOf(
+                    "Cc", "Ff", "Il1", "Kk",
+                    "Mm", "Oo0", "Pp", "Ss", "Uu", "Vv", "Ww", "Xx", "Zz"
+                )
+                var differenceCount = 0
+
+                for (i in 0 until message.content.length) {
+                    val userInput = message.content[i]
+                    val answer = lastKey.toString()[i]
+
+                    if (userInput != answer &&
+                        similarCharacters.any { it.contains(userInput) && it.contains(answer) }) {
+                        differenceCount += 1
+                    }
+                }
+
+                if (differenceCount <= 1) {
+                    val reward = (1..8).random()
+                    lastWinner = sender.id
+                    group.sendMessage(
+                        "${sender.nick}的答案与正确答案相近(相差1个相似字符), " +
+                                "获得 $reward 金币！"
+                    )
+                    lastKey = null
+                }
+            }
         }
         if (sender.id in config.admins && message.content == "!test new challenge") {
             newChallenge(group)

--- a/src/main/kotlin/Challenge.kt
+++ b/src/main/kotlin/Challenge.kt
@@ -89,8 +89,7 @@ fun configureTypeTextChallenge(bot: Bot) {
                 sender.profile.increaseMoney(reward.toDouble())
             } else if (message.content.length == (lastKey?.length ?: -1)) {
                 val similarCharacters: MutableList<String> = mutableListOf(
-                    "Cc", "Ff", "Il1", "Kk",
-                    "Mm", "Oo0", "Pp", "Ss", "Uu", "Vv", "Ww", "Xx", "Zz"
+                    "Cc", "Il1", "Oo0", "Pp", "Ss", "Uu", "Vv", "Ww", "Xx", "Zz"
                 )
                 var differenceCount = 0
 


### PR DESCRIPTION
当玩家回答出现1个相似字符时：
- 玩家会获得1~8个金币（上下限均比正常情况少两个）
- 玩家不会获得连续答对的额外奖励
- 若该玩家下次完全答对，仍会记为连续答对 相似字符包括["Cc", "Ff", "Il1", "Kk", "Mm", "Oo0", "Pp", "Ss", "Uu", "Vv", "Ww", "Xx", "Zz"]

在挑战系统中，有时会分不清部分大小写字母或其它相似字符，这是一种解决方案——答案出现少量相似字符仍然给予少量奖励。